### PR TITLE
Got it to compile on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,12 @@ Thumbs.db
 ehthumbs.db
 
 # Large files
-bin/
-dependencies/
-dependencies-build/
-dependencies-src/
-ipch/
+/bin
+/dependencies
+/dependencies-build
+/dependencies-src
+/ipch
+/build
 *.pch
 *.sdf
 
@@ -45,3 +46,7 @@ Icon
 # Files that might appear on external disk
 .Spotlight-V100
 .Trashes
+
+# exclude cmake for now
+CMakeLists.txt
+*cmake

--- a/src/engine/core/component/physicsComponent.cpp
+++ b/src/engine/core/component/physicsComponent.cpp
@@ -17,12 +17,12 @@ void PhysicsComponent::setAsBox( float x, float y, float z )
 {
 	btCollisionShape* boxShape = new  btBoxShape( btVector3( x,y,z ));
 
+	btVector3 nullVector(0,0,0);
+	boxShape->calculateLocalInertia( 1, nullVector);
 
-	boxShape->calculateLocalInertia( 1, btVector3(0,0,0));
-
-	btRigidBody::btRigidBodyConstructionInfo fallRigidBodyCI( 1, 
+	btRigidBody::btRigidBodyConstructionInfo fallRigidBodyCI( 1,
 		new btDefaultMotionState( btTransform( btQuaternion(0,0,0,1), btVector3(0,50,0)))
-		, boxShape, btVector3(0,0,0));
+		, boxShape, nullVector);
 	mBody = new btRigidBody(fallRigidBodyCI);
 	mPhysicsManager->getDiscreteDynamicsWorld()->addRigidBody(mBody);
 }

--- a/src/engine/core/event/EventListener.h
+++ b/src/engine/core/event/EventListener.h
@@ -10,19 +10,19 @@
 #define __YorkshireTea__EventListener__
 
 #include <iostream>
-#include "Event.h"
+#include "event.h"
 
 class EventListener
 {
 public:
-    
+
     virtual void handle( Event* e ) = 0;
-    
+
     void    setEventType( int eventType );
     int     getEventType( );
 private:
 
     int m_EventType;
-    
+
 };
 #endif /* defined(__YorkshireTea__EventListener__) */

--- a/src/engine/core/event/event.h
+++ b/src/engine/core/event/event.h
@@ -22,32 +22,32 @@ enum EV_EventType
 
 class Event
 {
-    
+
 public:
-    
+
     Event( int eventType );
-    
+
     int     getEventType();
-    
+
 private:
-    
+
     int     mEventType;
-    
+
 };
 
 class MouseEvent : public Event
 {
 public:
     MouseEvent( int eventType );
-    
+
     int m_MouseMoveX;
     int m_MouseMoveY;
     int m_MouseMoveZ;
-    
+
     int m_MouseX;
     int m_MouseY;
     int m_MouseZ;
-    
+
     int m_MouseButton;
     bool m_Released;
     bool m_Pressed;
@@ -57,11 +57,11 @@ class KeyboardEvent : public Event
 {
 public:
     KeyboardEvent( int eventType );
-    
-    bool m_Pressed;
-    bool m_Released;
-    
-    int m_Keycode;
+
+    bool mPressed;
+    bool mReleased;
+
+    int mKeycode;
 };
 
 #endif /* defined(__YorkshireTea__event__) */

--- a/src/engine/core/event/eventSystem.cpp
+++ b/src/engine/core/event/eventSystem.cpp
@@ -10,47 +10,47 @@
 
 EventSystem::EventSystem()
 {
-    
+
 }
 
 void EventSystem::dispatchEvent( Event* e )
 {
-    m_EventList.push(e);
+    mEventList.push(e);
 }
 
 void EventSystem::handleEvents()
 {
     // loop through events
-    while ( m_EventList.size() > 0 ) {
-        Event* e = m_EventList.front();
-        
+    while ( mEventList.size() > 0 ) {
+        Event* e = mEventList.front();
+
         // Dispatch events to listeners
-        for (auto i = m_EventListeners.begin(); i != m_EventListeners.end(); i++ )
+        for (auto i = mEventListeners.begin(); i != mEventListeners.end(); i++ )
         {
             if( (*i)->getEventType() && e->getEventType() )
                 (*i)->handle(e);
         }
-        
+
         // Delete the event
-        m_EventList.pop();
+        mEventList.pop();
         delete e;
     }
 }
 
 void EventSystem::registerListener(EventListener* e)
 {
-    m_EventListeners.push_back(e);
+    mEventListeners.push_back(e);
 }
 
 void EventSystem::deregisterListener(EventListener* e )
 {
-    for (auto i = m_EventListeners.begin(); i != m_EventListeners.end(); i++ ) {
-        
+    for (auto i = mEventListeners.begin(); i != mEventListeners.end(); i++ ) {
+
         if( e == (*i) )
         {
-            m_EventListeners.erase(i);
+            mEventListeners.erase(i);
             break;
         }
-            
+
     }
 }

--- a/src/engine/core/event/eventSystem.h
+++ b/src/engine/core/event/eventSystem.h
@@ -18,20 +18,20 @@
 class EventSystem
 {
 public:
-    
+
     EventSystem();
-    
+
     void dispatchEvent( Event* e );
-    
+
     void handleEvents();
-    
+
     void registerListener( EventListener* e );
     void deregisterListener( EventListener* e );
-    
+
 private:
-    
-    std::queue<Event*> m_EventList;
-    std::deque<EventListener*> m_EventListeners;
-    
+
+    std::queue<Event*> mEventList;
+    std::deque<EventListener*> mEventListeners;
+
 };
 #endif /* defined(__YorkshireTea__eventSystem__) */

--- a/src/engine/core/graphics/RenderSystem.cpp
+++ b/src/engine/core/graphics/RenderSystem.cpp
@@ -13,23 +13,28 @@
 RenderSystem::RenderSystem()
 {
     m_Root = new Ogre::Root("","","Ogre.log");
-    
+
     // Load the GL Rendersystem and set up
 	Ogre::String renderer = "RenderSystem_GL";
 
-#ifdef OGRE_DEBUG_MODE
+    // TheComet: *nix requires a relative path
+#ifndef WIN32
+    renderer = Ogre::String("./") + renderer;
+#endif
+
+#if defined(_DEBUG) && defined(WIN32)
 	renderer.append("_d");
 #endif
 
     m_Root->loadPlugin( renderer );
-    
+
     Ogre::RenderSystem* renderSystem = m_Root->getAvailableRenderers()[0];
 
     m_Root->setRenderSystem(renderSystem);
-    
+
     Ogre::NameValuePairList lParams;
-    
-    lParams["FSAA"] = "0"; 
+
+    lParams["FSAA"] = "0";
     lParams["vsync"] = "true";
     lParams["macAPI"] = "carbon";
 
@@ -45,7 +50,7 @@ RenderSystem::RenderSystem()
 	SDL_SysWMinfo info;
 	SDL_VERSION(&info.version);
 	SDL_GetWindowWMInfo( mSDLWindow, &info );
-	
+
 	size_t winHandle = reinterpret_cast<size_t>(info.info.win.window);
 	lParams["externalWindowHandle"] = Ogre::StringConverter::toString(winHandle);
 
@@ -57,7 +62,7 @@ RenderSystem::RenderSystem()
     m_RenderWindow = m_Root->createRenderWindow( "Window", 800, 600, false, &lParams );
 
     m_SceneMgr = m_Root->createSceneManager(Ogre::ST_GENERIC );
-    
+
     m_RootSceneNode = m_SceneMgr->getRootSceneNode();
     Ogre::ResourceGroupManager::getSingleton().createResourceGroup("Media");
 

--- a/src/engine/core/graphics/RenderSystem.h
+++ b/src/engine/core/graphics/RenderSystem.h
@@ -9,7 +9,7 @@
 #ifndef __YorkshireTea__gfxSystem__
 #define __YorkshireTea__gfxSystem__
 
-#include "Camera.h"
+#include "camera.h"
 
 class Camera;
     

--- a/src/engine/core/input/inputSystem.cpp
+++ b/src/engine/core/input/inputSystem.cpp
@@ -13,7 +13,7 @@
 InputSystem::InputSystem( EventSystem* eventSys )
 {
 	m_EventSystem = eventSys;
-    
+
 }
 
 void InputSystem::update()
@@ -23,9 +23,9 @@ void InputSystem::update()
 		if( m_inputEvent.type == SDL_KEYDOWN )
 		{
 			// Key down, create and dispatch event
-			KeyboardEvent*	e = new KeyboardEvent(EV_EventType::EV_KeyPress ); 
-			e->m_Pressed = true;
-			e->m_Keycode = m_inputEvent.key.keysym.scancode;
+			KeyboardEvent*	e = new KeyboardEvent(EV_KeyPress );
+			e->mPressed = true;
+			e->mKeycode = m_inputEvent.key.keysym.scancode;
 			m_EventSystem->dispatchEvent( e );
 		}
 	}

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -8,14 +8,14 @@
 #include "pch.h"
 #include <SDL.h>
 
-#include "Engine.h"
+#include "engine.h"
 
 
 Engine::Engine()
 {
 	SDL_Init( SDL_INIT_EVERYTHING );
     m_EngineShutdown = false;
-    
+
 	// Create Systems
     mRenderSystem = new RenderSystem();
     mEventSystem = new EventSystem();
@@ -38,7 +38,7 @@ Engine::Engine()
 	floor->renderComponent =  new RenderComponent( mRenderSystem, cube );
 	floor->mPosition = Ogre::Vector3( 0,0,0 );
 	floor->renderComponent->setAsBox(10.0f,0.5f,10.0f);
-	
+
 
 }
 
@@ -80,7 +80,7 @@ void Engine::handle( Event* e )
     {
         case EV_KeyPress:
             KeyboardEvent* ke = static_cast<KeyboardEvent*>(e);
-            switch (ke->m_Keycode)
+            switch (ke->mKeycode)
             {
 				case SDL_SCANCODE_ESCAPE: // Escape
                    m_EngineShutdown = true;
@@ -101,7 +101,7 @@ Camera* Engine::createCamera()
 {
     Camera* cam = new Camera( mRenderSystem->getRenderWindow(), mRenderSystem->getSceneMgr(), mRenderSystem->getRootSceneNode() );
     mRenderSystem->getCameraList()->push_back( cam );
-    
+
     cam->init();
     return cam;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,7 +13,11 @@
 extern "C"
 #endif
 
+#ifdef WIN32
 int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int)
+#else
+int main()
+#endif
 {
     Engine* engine = new Engine();
     engine->createCamera();
@@ -22,12 +26,12 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int)
 	cam->m_SceneNode->setPosition( 0.0f,12.0f, 20.0f );
 	cam->m_Camera->lookAt( 0,0.0f,0.0f );
 
-    
+
     while( !engine->isShuttingDown() )
     {
         engine->update();
     }
-    
+
     delete engine;
 	return 0;
 }


### PR DESCRIPTION
Some things to note for the future, to make your code more linux proof.
## Including Headers

Header files are case sensitive on Linux. I changed a lot of `#include "Event.h"` to `#include "event.h"`
## Shared libraries

On unix systems (mac included), there isn't really anything like a "debug build". A shared object built using release settings will still link against your game if you're building in debug mode. For this reason, Linux also doesn't have any **_d** suffixes.
## Debug macro

**_DEBUG** is the official identifier declared when the build type is debug.
## rvalue references

MSVC apparently bends the rules a little when passing non-const rvalue references around. The following code is illegal, but MSVC will compile it anyway.

```
struct Foo {};
void bar(Foo x) {}
int main()
{
        bar(Foo());
        return 0;
}
```

Output:

```
main.cpp:5:11: error: invalid initialization of non-const reference of type ‘Foo&’ from an rvalue of type ‘Foo’
  bar(Foo());
           ^
```
